### PR TITLE
Add ability to sync Azure Service principals

### DIFF
--- a/azure/src/main/java/com/starburstdata/azure/AzureConfig.java
+++ b/azure/src/main/java/com/starburstdata/azure/AzureConfig.java
@@ -8,6 +8,7 @@ public class AzureConfig
     private final String[] groupFilter;
 
     private final boolean createEmptyGroups;
+    private final boolean syncServicePrincipals;
     private final int syncInterval;
 
     private AzureConfig( Builder builder )
@@ -18,6 +19,7 @@ public class AzureConfig
         this.groupFilter = builder.groupFilter;
 
         this.createEmptyGroups = builder.createEmptyGroups;
+        this.syncServicePrincipals = builder.syncServicePrincipals;
         this.syncInterval = builder.syncInterval;
     }
 
@@ -46,6 +48,11 @@ public class AzureConfig
         return this.createEmptyGroups;
     }
 
+    public boolean syncServicePrincipals()
+    {
+        return this.syncServicePrincipals;
+    }
+
     public int syncInterval()
     {
         return this.syncInterval;
@@ -59,6 +66,7 @@ public class AzureConfig
         String[] groupFilter = {};
 
         boolean createEmptyGroups = false;
+        boolean syncServicePrincipals = false;
         int syncInterval = 0;
 
         public AzureConfig.Builder tenantId( String tenantId )
@@ -84,6 +92,10 @@ public class AzureConfig
         public AzureConfig.Builder createEmptyGroups( String flag )
         {
             this.createEmptyGroups = Boolean.parseBoolean( flag ); return this;
+        }
+        public AzureConfig.Builder syncServicePrincipals( String flag )
+        {
+            this.syncServicePrincipals = Boolean.parseBoolean( flag ); return this;
         }
 
         public AzureConfig.Builder syncInterval( String value )

--- a/azure/src/main/java/com/starburstdata/azure/model/AzureServicePrincipal.java
+++ b/azure/src/main/java/com/starburstdata/azure/model/AzureServicePrincipal.java
@@ -1,0 +1,28 @@
+package com.starburstdata.azure.model;
+
+import com.google.gson.annotations.SerializedName;
+
+public class AzureServicePrincipal
+{
+    @SerializedName("@odata.type")
+    String odataType;
+    @SerializedName("@odata.id")
+    String odataId;
+    String id;
+    String displayName;
+
+    public String odataType()
+    {
+        return this.odataType;
+    }
+
+    public String id()
+    {
+        return this.id;
+    }
+
+    public String displayName()
+    {
+        return this.displayName;
+    }
+}

--- a/azure/src/main/java/com/starburstdata/azure/model/AzureServicePrincipals.java
+++ b/azure/src/main/java/com/starburstdata/azure/model/AzureServicePrincipals.java
@@ -1,0 +1,54 @@
+package com.starburstdata.azure.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class AzureServicePrincipals
+{
+    @SerializedName("@odata.context")
+    String odataContext;
+    @SerializedName("@odata.nextLink")
+    String odataNextLink;
+    AzureServicePrincipal[] value;
+
+    public String odataNextLink()
+    {
+        return this.odataNextLink;
+    }
+
+    public AzureServicePrincipal[] value()
+    {
+        return this.value;
+    }
+
+    public AzureServicePrincipal[] users()
+    {
+        var list = new ArrayList<AzureServicePrincipal>();
+
+        for( var servicePrincipal : value )
+        {
+            if( "#microsoft.graph.servicePrincipal".equals( servicePrincipal.odataType ) )
+            {
+                list.add( servicePrincipal );
+            }
+        }
+
+        return list.toArray( new AzureServicePrincipal[0] );
+    }
+
+    public AzureServicePrincipals append(AzureServicePrincipal[] value )
+    {
+        // Increase the size of the servicePrincipal array and copy in the objects
+        AzureServicePrincipal[] result = Arrays.copyOf(this.value, this.value.length + value.length);
+
+        // Copy the objects from the parameter to the end of the servicePrincipal array
+        System.arraycopy(value, 0, result, this.value.length, value.length);
+
+        // Save the resulting array to the object
+        this.value = result;
+
+        return this;
+    }
+}

--- a/main/src/main/java/com/starburstdata/Configuration.java
+++ b/main/src/main/java/com/starburstdata/Configuration.java
@@ -49,6 +49,7 @@ public class Configuration
     public final static String SOURCE_AZURE_CLIENT_ID = "source.azure.client-id";
     public final static String SOURCE_AZURE_CLIENT_SECRET = "source.azure.client-secret";
     public final static String SOURCE_AZURE_GROUP_FILTER = "source.azure.group-filter";
+    public final static String SOURCE_AZURE_SYNC_SERVICE_PRINCIPALS = "source.azure.sync-service-principals";
 
     //
     // Ranger

--- a/main/src/main/java/com/starburstdata/Main.java
+++ b/main/src/main/java/com/starburstdata/Main.java
@@ -271,6 +271,11 @@ public class Main
             builder.syncInterval( config.get( Configuration.SYNC_INTERVAL ) );
         }
 
+        if( config.exists( Configuration.SOURCE_AZURE_SYNC_SERVICE_PRINCIPALS ) )
+        {
+            builder.syncServicePrincipals( config.get( Configuration.SOURCE_AZURE_SYNC_SERVICE_PRINCIPALS ) );
+        }
+
         return builder.build();
     }
 


### PR DESCRIPTION
add flag to enable syncing service principals that are part of synced groups. Currently syncs SP with its guid as the username, based on the constraints of SP access tokens